### PR TITLE
WIP on issue 51

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ out
 /.env.development.local
 /.env.test.local
 /.env.production.local
+/.env.production
 
 npm-debug.log*
 yarn-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ out
 /.env.test.local
 /.env.production.local
 /.env.production
+/.env.development
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/config.js
+++ b/src/config.js
@@ -12,15 +12,16 @@ export const auth0Config = {
 };
 
 export const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  databaseURL: process.env.NEXT_PUBLIC_FIREBASE_DATABASE_URL,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
+	apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+	authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+	// databaseURL: process.env.NEXT_PUBLIC_FIREBASE_DATABASE_URL,
+	projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+	storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+	messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+	appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+	measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
+
 
 /*export const gtmConfig = {
   containerId: process.env.NEXT_PUBLIC_GTM_CONTAINER_ID

--- a/src/config.js
+++ b/src/config.js
@@ -12,14 +12,14 @@ export const auth0Config = {
 };
 
 export const firebaseConfig = {
-  apiKey: "AIzaSyCa08_y3n-_qRFvzR7Kw-R4VW8pKzj7WJI",
-  authDomain: "seeing-is-beleiving.firebaseapp.com",
-  databaseURL: "https://seeing-is-beleiving-default-rtdb.firebaseio.com",
-  projectId: "seeing-is-beleiving",
-  storageBucket: "seeing-is-beleiving.appspot.com",
-  messagingSenderId: "955481005378",
-  appId: "1:955481005378:web:d5145ada8733d1804d7cdb",
-  measurementId: "G-41PZRQMEBP"
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  databaseURL: process.env.NEXT_PUBLIC_FIREBASE_DATABASE_URL,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
 /*export const gtmConfig = {

--- a/src/utils/firebase.js
+++ b/src/utils/firebase.js
@@ -1,11 +1,8 @@
 import firebase from 'firebase/app';
 import 'firebase/auth';
 
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_PUBLIC_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID
-}
+// import the configured Firebase instance from config.js
+import firebaseConfig from '../config';
 
 //If an firebase app hasn't already been created
 if (!firebase.apps.length) {


### PR DESCRIPTION
Currently, there are hard coded credentials for access to the Firebase associated with SIB that are visible in the source code on GitHub. This means that anyone looking at our source code can see these credentials which is not good for the security of the application. I replaced the hard coded values in config.js with references to the hardcoded values in either .env.local or .env.production which are loaded based on running npm run dev (for development) and npm run build then npm start (for production). These files are included in the .gitignore meaning that they won't be pushed up to the source code visible on GitHub. Currently both the .end.local and .env.production have the same credentials since we only have one database, however once the development database is created, those credentials will be placed in the .env.local file. Any developer wanting to run this code from now on will need to obtain a copy of the .env.local and .env.production files. 