### PR TITLE
Teacher Access to Tabs and Class Permissions - Fixes Issue #75

### DIFF
--- a/src/components/dashboard/dashboard-sidebar.js
+++ b/src/components/dashboard/dashboard-sidebar.js
@@ -15,6 +15,7 @@ import { InstructionsBook as InstructionsIcon } from '../../icons/instruction-bo
 import { Language as LanguageIcon } from '../../icons/language';
 import { Save as SaveIcon } from '../../icons/save';
 import { DotsHorizontal as DotsHorizontalIcon } from '../../icons/dots-horizontal'	
+import {db} from "../../lib/firebase";
 
 const getSectionsStudent = (t) => [
 	{
@@ -54,7 +55,7 @@ const getSectionsStudent = (t) => [
 const ROUTES = {
 	home: "/teacher",
 	manageClasses: "/teacher/manage_class",
-	wordList: "/teacher/word-list",
+	wordList: "/teacher/wordlist",
 	addHomework: "/teacher/addHomework",
 	language: "/teacher/language",
 	words: "/tacher/word"
@@ -86,7 +87,7 @@ const getSectionsTeacher = (t) => [
 				icon: <DotsHorizontalIcon fontSize="small" />,
 				children: [
 					{
-						title: t("Words Library"), path: ROUTES.wordlist
+						title: t("Words Library"), path: ROUTES.wordList
 					},
 					{
 						title: t('Manage Classes'), path: ROUTES.manageClasses
@@ -115,7 +116,7 @@ const getModifiedSectionsTeacher = (t) => [
 				children: [
 					{
 						title: t('Manage Classes'), path: ROUTES.manageClasses
-					}
+					},
 				]
 			},
 		],
@@ -178,23 +179,27 @@ export const DashboardSidebar = (props) => {
 	const lgUp = useMediaQuery((theme) => theme.breakpoints.up("lg"), {
 		noSsr: true,
 	});
-	const [fetchedClasses,setFetchedClasses]=useState(null)
-	const fetchDataClasses= async()=>{
-		const collection = await db.collection("classes");
-		const results=[]
-		await collection.where("teacher","==",user.id)
-		  .get()
-		  .then(snapshot=>{
-			if(snapshot)
-			{snapshot.forEach(doc=>{
-			  results.push({id:doc.id,...doc.data()})
-			})}
-		  })
-		  if(results.length > 0) {window.res = 1}
-		  else window.res = 0
-		  console.log("window.res",window.res)
+	const [fetchedClasses,setFetchedClasses]=useState(null);
+	const [res, setRes] = useState(0);
 
-		  setFetchedClasses(results);
+	useEffect(() => {
+		fetchDataClasses();
+	}, []);
+	
+
+	const fetchDataClasses=async () =>{
+		const collection= await db.collection("classes");
+		let results=[];
+		await collection.where("teacher","==",user.id).get().then(snapshot=>{
+			snapshot.docs.forEach(doc=>{
+				const newClass={id:doc.id,...doc.data()}
+				results.push(newClass)
+			})
+		})
+		if (results.length > 0) {
+			setRes(1);
+		}
+		setFetchedClasses(results)
 	}
 
 
@@ -206,8 +211,8 @@ export const DashboardSidebar = (props) => {
 		} else if (user.status === "Administrator") {
 			return getSectionsAdministrator(t);
 		} else {
-			if(window.res == 1) return getSectionsTeacher(t);
-			else return getModifiedSectionsTeacher(t)
+			if(res == 1) return getSectionsTeacher(t);
+			else return getModifiedSectionsTeacher(t);
 		}
 	}, [t]);
 

--- a/src/pages/teacher/addHomework.js
+++ b/src/pages/teacher/addHomework.js
@@ -53,7 +53,7 @@ const Page = () => {
 	const fetchDataClasses=async () =>{
 		const collection= await db.collection("classes");
 		let results=[];
-		await collection.get().then(snapshot=>{
+		await collection.where("teacher","==",user.id).get().then(snapshot=>{
 			snapshot.docs.forEach(doc=>{
 				const newClass={id:doc.id,...doc.data()}
 				results.push(newClass)

--- a/src/pages/teacher/manage_class.js
+++ b/src/pages/teacher/manage_class.js
@@ -13,10 +13,12 @@ import EditClassForm from "../../components/teacher/classPage/EditClassForm";
 import DeleteClassForm from "../../components/teacher/classPage/DeleteClassForm";
 import SwipeableViews from "react-swipeable-views";
 import {db} from "../../lib/firebase";
+import { useAuth } from '../../hooks/use-auth';
 
 const ClassPage = () => {
 	const [activeStep, setActiveStep] = useState(0);
 	const [complete, setComplete] = useState(false);
+	const { user } = useAuth();
 	const [index, setIndex] = useState(0);
 	const [languages, setLanguages] = useState([]);
 	const [terms, setTerms] = useState([]);
@@ -68,7 +70,7 @@ const ClassPage = () => {
 	const fetchDataClasses=async () =>{
 		const collection= await db.collection("classes");
 		let results=[];
-		await collection.get().then(snapshot=>{
+		await collection.where("teacher","==",user.id).get().then(snapshot=>{
 			snapshot.docs.forEach(doc=>{
 				const newClass={id:doc.id,...doc.data()}
 				results.push(newClass)


### PR DESCRIPTION
Previously, teacher accounts were able to access the "Add Homework" and "Words Library" tabs even if they were not managing a class which would give them the ability to make changes to other teachers' classes. A fix was introduced however there was a bug. 
As described in the issue 75 description, now teacher accounts were unable to access unable to access the "Add Homework" and "Words Library" tabs on sidebar even if they were managing a class.

This PR addresses that issue by ensuring that teachers who are managing a class can access their appropriate tabs and teachers not yet managing a class can access their appropriate tabs.
![teachernoclasses](https://github.com/oss-slu/Seeing-is-Believing/assets/112146951/5482f8cd-a978-4aad-98bc-074b0f9e4ab6)
As shown above, the teacher account with "No managed classes" cannot access the "Add Homework" and "Words Library" tabs

![teacherwithclass](https://github.com/oss-slu/Seeing-is-Believing/assets/112146951/9cb045eb-ac7c-4625-8c42-9d5f77e35e25)
As shown above, the teacher account with a managed class can access the "Add Homework" and "Words Library" tabs.

Reviewer can experience the impact of these changes by pulling down the issue_75 branch, creating a teacher account, verifying if the dashboard sidebar contains only "Manage Classes", then adding a class for that teacher account to manage and verifying if the dashboard sidebar contains "Manage Classes", "Add Homework" and "Words Library".

This PR also includes a small fix related to the path to "Words Library" page. Previously, clicking the "Words Library" button resulted in a 404 error, however a small path change from"word-list" to "wordlist" successfully routed users to the correct location upon clicking the "Words Library" button.