### PR TITLE
Updated the admin word page to import from admin components rather than teacher

### DIFF
--- a/src/pages/administrator/word.js
+++ b/src/pages/administrator/word.js
@@ -8,8 +8,8 @@ import {
 } from "@mui/material";
 import {AuthGuard} from "../../components/authentication/auth-guard";
 import {DashboardLayout} from "../../components/dashboard/dashboard-layout";
-import AddWordForm from "../../components/teacher/word/AddWordForm";
-import EditWordForm from "../../components/teacher/word/EditWordForm";
+import AddWordForm from "../../components/administrator/word/AddWordForm";
+import EditWordForm from "../../components/administrator/word/EditWordForm";
 import SwipeableViews from "react-swipeable-views";
 import {db} from "../../lib/firebase";
 


### PR DESCRIPTION
The form being imported to the admin word page was the form described in the teacher component section of our code, and when editing the admin component there were no changes taking place because of this. Re-imported so the correct form is being used for the admin page.