### PR TITLE
Fixes Issue 74

### DIFF
--- a/src/pages/administrator/word.js
+++ b/src/pages/administrator/word.js
@@ -8,8 +8,8 @@ import {
 } from "@mui/material";
 import {AuthGuard} from "../../components/authentication/auth-guard";
 import {DashboardLayout} from "../../components/dashboard/dashboard-layout";
-import AddWordForm from "../../components/teacher/word/AddWordForm";
-import EditWordForm from "../../components/teacher/word/EditWordForm";
+import AddWordForm from "../../components/administrator/word/AddWordForm";
+import EditWordForm from "../../components/administrator/word/EditWordForm";
 import SwipeableViews from "react-swipeable-views";
 import {db} from "../../lib/firebase";
 


### PR DESCRIPTION
Changed an import statement to import the correct add word form. The admin page was originally importing the word form from the teacher components, and thus changes to the admin form would not show up on the page. Now the correct form is imported and the admin page has a Save option for adding words.