### PR TITLE
Fixes issue 85

### DIFF
--- a/src/pages/administrator/homeworks/[hid].js
+++ b/src/pages/administrator/homeworks/[hid].js
@@ -336,7 +336,7 @@ const SubSection = (props) => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -363,7 +363,7 @@ const SubSection = (props) => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainNonNativeRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -427,7 +427,7 @@ const SubSection = (props) => {
 			plugins: [
 				SpectrogramPlugin.create({
 					container: specRecordRef.current,
-					fftSamples: 2048,
+					fftSamples: 1024,
 					noverlap: 0,
 					labels: false,
 					colorMap: COLORMAPS.hsv,
@@ -540,9 +540,9 @@ const SubSection = (props) => {
 				<Grid
 					sx={{
 						maxWidth: "665px",
-						maxHeight: "350px",
-						overflowX: "scroll",
-						overflowY: "scroll",
+						maxHeight: "450px",
+						overflowX: "clip",
+						overflowY: "clip",
 					}}
 				>
 					<div
@@ -615,9 +615,9 @@ const SubSection = (props) => {
 					<Grid
 						sx={{
 							maxWidth: "665px",
-							maxHeight: "350px",
-							overflowX: "scroll",
-							overflowY: "scroll",
+							axHeight: "450px",
+							overflowX: "clip",
+							overflowY: "clip",
 						}}
 					>
 						<div
@@ -691,9 +691,9 @@ const SubSection = (props) => {
 				<Grid
 					sx={{
 						maxWidth: "665px",
-						maxHeight: "350px",
-						overflowX: "scroll",
-						overflowY: "scroll",
+						maxHeight: "450px",
+						overflowX: "clip",
+						overflowY: "clip",
 					}}
 				>
 					<div

--- a/src/pages/administrator/wordlist.js
+++ b/src/pages/administrator/wordlist.js
@@ -105,7 +105,7 @@ const WordList = () => {
 			plugins: [
 				SpectrogramPlugin.create({
 					container: specRecordRef.current,
-					fftSamples: 2048,
+					fftSamples: 1024,
 					noverlap: 0,
 					labels: false,
 					colorMap: COLORMAPS.hsv,
@@ -129,7 +129,7 @@ const WordList = () => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -157,7 +157,7 @@ const WordList = () => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainNonNativeRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -440,9 +440,9 @@ const WordList = () => {
 										<Grid
 											sx={{
 												maxWidth: "665px",
-												maxHeight: "350px",
-												overflowX: "scroll",
-												overflowY: "scroll",
+												maxHeight: "450px",
+												overflowX: "clip",
+												overflowY: "clip",
 											}}
 										>
 											<div
@@ -515,9 +515,9 @@ const WordList = () => {
 										<Grid
 											sx={{
 												maxWidth: "665px",
-												maxHeight: "350px",
-												overflowX: "scroll",
-												overflowY: "scroll",
+												maxHeight: "450px",
+												overflowX: "clip",
+												overflowY: "clip",
 											}}
 										>
 											<div

--- a/src/pages/student/homework_grad.js
+++ b/src/pages/student/homework_grad.js
@@ -289,7 +289,7 @@ const SubSection = (props) => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -317,7 +317,7 @@ const SubSection = (props) => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainNonNativeRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -381,7 +381,7 @@ const SubSection = (props) => {
 			plugins: [
 				SpectrogramPlugin.create({
 					container: specRecordRef.current,
-					fftSamples: 2048,
+					fftSamples: 1024,
 					noverlap: 0,
 					labels: false,
 					colorMap: COLORMAPS.hsv,
@@ -501,9 +501,9 @@ const SubSection = (props) => {
 				<Grid
 					sx={{
 						maxWidth: "665px",
-						maxHeight: "350px",
-						overflowX: "scroll",
-						overflowY: "scroll",
+						maxHeight: "450px",
+						overflowX: "clip",
+						overflowY: "clip",
 					}}
 				>
 					<div
@@ -575,9 +575,9 @@ const SubSection = (props) => {
 					<Grid
 						sx={{
 							maxWidth: "665px",
-							maxHeight: "350px",
-							overflowX: "scroll",
-							overflowY: "scroll",
+							maxHeight: "450px",
+							overflowX: "clip",
+							overflowY: "clip",
 						}}
 					>
 						<div
@@ -650,9 +650,9 @@ const SubSection = (props) => {
 				<Grid
 					sx={{
 						maxWidth: "665px",
-						maxHeight: "350px",
-						overflowX: "scroll",
-						overflowY: "scroll",
+						maxHeight: "450px",
+						overflowX: "clip",
+						overflowY: "clip",
 					}}
 				>
 					<div

--- a/src/pages/student/homeworks/[hid].js
+++ b/src/pages/student/homeworks/[hid].js
@@ -428,7 +428,7 @@ const SubSection = (props) => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -456,7 +456,7 @@ const SubSection = (props) => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainNonNativeRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -537,7 +537,7 @@ const SubSection = (props) => {
 			plugins: [
 				SpectrogramPlugin.create({
 					container: specRecordRef.current,
-					fftSamples: 2048,
+					fftSamples: 1024,
 					noverlap: 0,
 					labels: false,
 					colorMap: COLORMAPS.hsv,
@@ -677,9 +677,9 @@ const SubSection = (props) => {
 				<Grid
 					sx={{
 						maxWidth: "665px",
-						maxHeight: "350px",
-						overflowX: "scroll",
-						overflowY: "scroll",
+						maxHeight: "450px",
+						overflowX: "clip",
+						overflowY: "clip",
 					}}
 				>
 					<div
@@ -771,9 +771,9 @@ const SubSection = (props) => {
 					<Grid
 						sx={{
 							maxWidth: "665px",
-							maxHeight: "350px",
-							overflowX: "scroll",
-							overflowY: "scroll",
+							maxHeight: "450px",
+							overflowX: "clip",
+							overflowY: "clip",
 						}}
 					>
 						<div
@@ -847,9 +847,9 @@ const SubSection = (props) => {
 				<Grid
 					sx={{
 						maxWidth: "665px",
-						maxHeight: "350px",
-						overflowX: "scroll",
-						overflowY: "scroll",
+						maxHeight: "450px",
+						overflowX: "clip",
+						overflowY: "clip",
 					}}
 				>
 					<div

--- a/src/pages/student/practice.js
+++ b/src/pages/student/practice.js
@@ -108,7 +108,7 @@ const Practice = () => {
 			plugins: [
 				SpectrogramPlugin.create({
 					container: specRecordRef.current,
-					fftSamples: 2048,
+					fftSamples: 1024,
 					noverlap: 0,
 					labels: false,
 					colorMap: COLORMAPS.hsv,
@@ -132,7 +132,7 @@ const Practice = () => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -160,7 +160,7 @@ const Practice = () => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainNonNativeRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -448,9 +448,9 @@ const Practice = () => {
 										<Grid
 											sx={{
 												maxWidth: "665px",
-												maxHeight: "350px",
-												overflowX: "scroll",
-												overflowY: "scroll",
+												maxHeight: "450px",
+												overflowX: "clip",
+												overflowY: "clip",
 											}}
 										>
 											<div
@@ -472,6 +472,8 @@ const Practice = () => {
 												<div
 													style={{
 														visibility: "hidden",
+														width: "665px",
+														height: "300px",
 													}}
 													ref={specMainContainerRef}
 												></div>
@@ -557,9 +559,9 @@ const Practice = () => {
 											<Grid
 												sx={{
 													maxWidth: "665px",
-													maxHeight: "350px",
-													overflowX: "scroll",
-													overflowY: "scroll",
+													maxHeight: "450px",
+													overflowX: "clip",
+													overflowY: "clip",
 												}}
 											>
 												<div
@@ -634,9 +636,9 @@ const Practice = () => {
 										<Grid
 											sx={{
 												maxWidth: "665px",
-												maxHeight: "350px",
-												overflowX: "scroll",
-												overflowY: "scroll",
+												maxHeight: "450px",
+												overflowX: "clip",
+												overflowY: "clip",
 											}}
 										>
 											<div

--- a/src/pages/teacher/homeworks/[hid].js
+++ b/src/pages/teacher/homeworks/[hid].js
@@ -337,7 +337,7 @@ const SubSection = (props) => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -364,7 +364,7 @@ const SubSection = (props) => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainNonNativeRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -428,7 +428,7 @@ const SubSection = (props) => {
 			plugins: [
 				SpectrogramPlugin.create({
 					container: specRecordRef.current,
-					fftSamples: 2048,
+					fftSamples: 1024,
 					noverlap: 0,
 					labels: false,
 					colorMap: COLORMAPS.hsv,
@@ -541,9 +541,9 @@ const SubSection = (props) => {
 				<Grid
 					sx={{
 						maxWidth: "665px",
-						maxHeight: "350px",
-						overflowX: "scroll",
-						overflowY: "scroll",
+						maxHeight: "450px",
+						overflowX: "clip",
+						overflowY: "clip",
 					}}
 				>
 					<div
@@ -616,9 +616,9 @@ const SubSection = (props) => {
 					<Grid
 						sx={{
 							maxWidth: "665px",
-							maxHeight: "350px",
-							overflowX: "scroll",
-							overflowY: "scroll",
+							maxHeight: "450px",
+							overflowX: "clip",
+							overflowY: "clip",
 						}}
 					>
 						<div
@@ -692,9 +692,9 @@ const SubSection = (props) => {
 				<Grid
 					sx={{
 						maxWidth: "665px",
-						maxHeight: "350px",
-						overflowX: "scroll",
-						overflowY: "scroll",
+						maxHeight: "450px",
+						overflowX: "clip",
+						overflowY: "clip",
 					}}
 				>
 					<div

--- a/src/pages/teacher/wordlist.js
+++ b/src/pages/teacher/wordlist.js
@@ -107,7 +107,7 @@ const WordList = () => {
 			plugins: [
 				SpectrogramPlugin.create({
 					container: specRecordRef.current,
-					fftSamples: 2048,
+					fftSamples: 1024,
 					noverlap: 0,
 					labels: false,
 					colorMap: COLORMAPS.hsv,
@@ -131,7 +131,7 @@ const WordList = () => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -159,7 +159,7 @@ const WordList = () => {
 					SpectrogramPlugin.create({
 						wavesurfer: wavesurfer,
 						container: specMainNonNativeRef.current,
-						fftSamples: 2048,
+						fftSamples: 1024,
 						noverlap: 0,
 						labels: false,
 						colorMap: COLORMAPS.hsv,
@@ -443,9 +443,9 @@ const WordList = () => {
 										<Grid
 											sx={{
 												maxWidth: "665px",
-												maxHeight: "350px",
-												overflowX: "scroll",
-												overflowY: "scroll",
+												maxHeight: "450px",
+												overflowX: "clip",
+												overflowY: "clip",
 											}}
 										>
 											<div
@@ -555,9 +555,9 @@ const WordList = () => {
 											<Grid
 												sx={{
 													maxWidth: "665px",
-													maxHeight: "350px",
-													overflowX: "scroll",
-													overflowY: "scroll",
+												maxHeight: "450px",
+												overflowX: "clip",
+												overflowY: "clip",
 												}}
 											>
 												<div
@@ -632,9 +632,9 @@ const WordList = () => {
 										<Grid
 											sx={{
 												maxWidth: "665px",
-												maxHeight: "350px",
-												overflowX: "scroll",
-												overflowY: "scroll",
+												maxHeight: "450px",
+												overflowX: "clip",
+												overflowY: "clip",
 											}}
 										>
 											<div


### PR DESCRIPTION
Modified container and spectrogram size to fit in box without needing to scroll. This was done by editing the height of the containers, as well as updating fftsamples variable upon creation of any spectrogram throughout the code base. In particular the container widths were changed from 350px to 450px, and overflow was set to clip. The fftsamples variable was changed from 2048 to 1024 for each spectrogram creation instance. For reference here is a before and after picture of how the spectrograms look on the page: 

Before:
<img width="393" alt="image" src="https://github.com/oss-slu/Seeing-is-Believing/assets/123423248/04da188e-3b11-4c3e-b91c-1651c99c93fd">
<img width="384" alt="image" src="https://github.com/oss-slu/Seeing-is-Believing/assets/123423248/0fd6aae7-5ab5-40ae-b512-be47a2380ec1">


After:
<img width="392" alt="image" src="https://github.com/oss-slu/Seeing-is-Believing/assets/123423248/33252f69-75f4-4381-96bc-9a798cd15b00">
