### PR TITLE
Fixing RTL Content Punctuation Issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@sendgrid/mail": "^7.6.1",
         "axios": "^0.25.0",
         "babel-polyfill": "^6.26.0",
+        "caniuse-lite": "^1.0.30001607",
         "date-fns": "^2.21.3",
         "dompurify": "^2.3.6",
         "draft-convert": "^2.1.12",
@@ -26,7 +27,7 @@
         "firebase": "^8.2.3",
         "formik": "^2.2.7",
         "gray-matter": "^4.0.3",
-        "next": "^12.3.4",
+        "next": "^12.0.9",
         "nprogress": "^0.2.0",
         "numeral": "^2.0.6",
         "prop-types": "^15.7.2",
@@ -3734,6 +3735,14 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
+      "integrity": "sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -4585,9 +4594,9 @@
       "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001534",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001534.tgz",
-      "integrity": "sha512-vlPVrhsCS7XaSh2VvWluIQEzVhefrUQcEsQWSS5A5V+dM07uv1qHeQzAOTGIMy9i3e9bH15+muvI/UHojVgS/Q==",
+      "version": "1.0.30001607",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
+      "integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w==",
       "funding": [
         {
           "type": "opencollective",
@@ -13053,6 +13062,14 @@
         "@svgr/plugin-svgo": "8.1.0"
       }
     },
+    "@swc/helpers": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
+      "integrity": "sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
     "@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -13715,9 +13732,9 @@
       "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
     },
     "caniuse-lite": {
-      "version": "1.0.30001534",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001534.tgz",
-      "integrity": "sha512-vlPVrhsCS7XaSh2VvWluIQEzVhefrUQcEsQWSS5A5V+dM07uv1qHeQzAOTGIMy9i3e9bH15+muvI/UHojVgS/Q=="
+      "version": "1.0.30001607",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
+      "integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -17509,9 +17526,9 @@
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
     },
     "styled-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
-      "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz",
+      "integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==",
       "requires": {}
     },
     "stylis": {
@@ -17934,6 +17951,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
       "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
+      "requires": {}
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "requires": {}
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@sendgrid/mail": "^7.6.1",
     "axios": "^0.25.0",
     "babel-polyfill": "^6.26.0",
+    "caniuse-lite": "^1.0.30001607",
     "date-fns": "^2.21.3",
     "dompurify": "^2.3.6",
     "draft-convert": "^2.1.12",

--- a/src/pages/administrator/index.js
+++ b/src/pages/administrator/index.js
@@ -34,6 +34,7 @@ const Overview = () => {
 	const [languages,setLanguages]=useState(null)
 	const [isFetching,setIsFetching]=useState(true)
 	const [showHelpForm,setShowHelpForm]=useState(false);
+	const formatLTRText = (text) => `\u202A${text}\u202C`;
 
   const fetchDataClasses= async()=>{
     const collection = await db.collection("classes");
@@ -119,14 +120,13 @@ const Overview = () => {
 										</Typography>
 									</Box>
 									<Typography sx={{mt: 2}} variant="h6">
-										Need help figuring things out?
+										{formatLTRText("Need help figuring things out?")}
 									</Typography>
 									<Typography
 										color="textSecondary"
 										variant="body2"
 									>
-										In case there is something going wrong, please click below and let us know
-										what went wrong.
+										{formatLTRText("In case there is something going wrong, please click below and let us know what went wrong.")}
 									</Typography>
 								</CardContent>
 								<Divider />

--- a/src/pages/student/index.js
+++ b/src/pages/student/index.js
@@ -34,6 +34,7 @@ const Overview = () => {
 	const [languages,setLanguages]=useState(null)
 	const [isFetching,setIsFetching]=useState(true)
 	const [showHelpForm,setShowHelpForm]=useState(false);
+	const formatLTRText = (text) => `\u202A${text}\u202C`;
 
   const fetchDataClasses= async()=>{
     const collection = await db.collection("classes");
@@ -152,14 +153,13 @@ const Overview = () => {
 										</Typography>
 									</Box>
 									<Typography sx={{mt: 2}} variant="h6">
-										Need help figuring things out?
+										{formatLTRText("Need help figuring things out?")}
 									</Typography>
 									<Typography
 										color="textSecondary"
 										variant="body2"
 									>
-										In case there is something going wrong, please click below and let us know
-										what went wrong.
+										{formatLTRText("In case there is something going wrong, please click below and let us know what went wrong.")}
 									</Typography>
 								</CardContent>
 								<Divider />

--- a/src/pages/student/instructions.js
+++ b/src/pages/student/instructions.js
@@ -40,6 +40,7 @@ const Overview = () => {
 		alignItems:"center",
 		margin:50,
 	};
+	const formatLTRText = (text) => `\u202A${text}\u202C`;
     const YoutubeEmbed = ({ embedId }) => (
         <div className="video-responsive">
           <iframe
@@ -121,14 +122,13 @@ const Overview = () => {
 										</Typography>
 									</Box>
 									<Typography sx={{mt: 2}} variant="h6">
-										Need help figuring things out?
+										{formatLTRText("Need help figuring things out?")}
 									</Typography>
 									<Typography
 										color="textSecondary"
 										variant="body2"
 									>
-										In case there is something going wrong, please click below and let us know
-										what went wrong.
+										{formatLTRText("In case there is something going wrong, please click below and let us know what went wrong.")}
 									</Typography>
 								</CardContent>
 								<Divider />

--- a/src/pages/teacher/index.js
+++ b/src/pages/teacher/index.js
@@ -34,6 +34,7 @@ const Overview = () => {
 	const [languages,setLanguages]=useState(null)
 	const [isFetching,setIsFetching]=useState(true)
 	const [showHelpForm,setShowHelpForm]=useState(false);
+	const formatLTRText = (text) => `\u202A${text}\u202C`;
 
   const fetchDataClasses= async()=>{
     const collection = await db.collection("classes");
@@ -153,14 +154,13 @@ const Overview = () => {
 										</Typography>
 									</Box>
 									<Typography sx={{mt: 2}} variant="h6">
-										Need help figuring things out?
+										{formatLTRText("Need help figuring things out?")}
 									</Typography>
 									<Typography
 										color="textSecondary"
 										variant="body2"
 									>
-										In case there is something going wrong, please click below and let us know
-										what went wrong.
+										{formatLTRText("In case there is something going wrong, please click below and let us know what went wrong.")}
 									</Typography>
 								</CardContent>
 								<Divider />

--- a/src/pages/teacher/wordlist.js
+++ b/src/pages/teacher/wordlist.js
@@ -84,6 +84,7 @@ const WordList = () => {
 	const [isRecordedPlaying, setIsRecordedPlaying] = useState(false);
 	const {status, startRecording, stopRecording, mediaBlobUrl, clearBlobUrl} =
 		useReactMediaRecorder({audio: true});
+	const formatLTRText = (text) => `\u202A${text}\u202C`;
 
 	useEffect(() => {
 		if (mediaBlobUrl && mediaBlobUrl != "") {
@@ -395,7 +396,7 @@ const WordList = () => {
 												<div
 													style={{ color: "#65748B" }}
 													dangerouslySetInnerHTML={createMarkup(
-														word.description
+														formatLTRText(word.description)
 													)}
 												></div>
 											</Grid>

--- a/src/pages/teacher/wordlist.js
+++ b/src/pages/teacher/wordlist.js
@@ -307,7 +307,7 @@ const WordList = () => {
 	if (!router.isReady) {
 		return null;
 	}
-
+// determining how to fix ltr format for description
 	return (
 		<>
 			<Head>
@@ -389,7 +389,7 @@ const WordList = () => {
 											</Typography>
 										</Grid>
 										<Grid xs={12} px={3} mt={2} item>
-											<Typography variant="subtitle1" sx={{ display: "block" }}>
+											<Typography variant="subtitle1" sx={{ display: "block" }}> 										
 												Description
 											</Typography>
 											<Grid md={10}>

--- a/src/pages/teacher/wordlist.js
+++ b/src/pages/teacher/wordlist.js
@@ -307,7 +307,7 @@ const WordList = () => {
 	if (!router.isReady) {
 		return null;
 	}
-// determining how to fix ltr format for description
+
 	return (
 		<>
 			<Head>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
     /* Language and Environment */
-    "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */// "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */ // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
@@ -21,16 +21,18 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
     /* Modules */
-    "module": "commonjs", /* Specify what module code is generated. */// "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "module": "commonjs", /* Specify what module code is generated. */ // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-     "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-     "paths": {
-      "cypress/*": ["./node_modules/cypress/*"]
-     },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    "baseUrl": "./", /* Specify the base directory to resolve non-relative module names. */
+    "paths": {
+      "cypress/*": [
+        "./node_modules/cypress/*"
+      ]
+    }, /* Specify a set of entries that re-map imports to additional lookup locations. */// "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-     "types": ["cypress"],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    "types": [
+      "cypress"
+    ], /* Specify type package names to be included without being referenced in a source file. */// "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
@@ -65,9 +67,9 @@
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */// "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. *//* Type Checking */
-    "strict": true, /* Enable all strict type-checking options. */// "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */ // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */ /* Type Checking */
+    "strict": true, /* Enable all strict type-checking options. */ // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
@@ -98,7 +100,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "moduleResolution": "node"
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
Fixes Issue #95

**What was changed?**

All instances of index.js files(src/pages/administrator, src/pages/teacher, and src/pages/student) and instructions.js were changed. 

**Why was it changed?**

In a previous modification, we added an ability to activate RTL content. While useful, the RTL plugin had a bug where it would not align the punctuation to the end of the sentence. For example, "Need help figuring things out?" would display as "?Need help figuring things out".

**How was it changed?**

I added a function, formatLTRText, that wraps a value with LRE/PDF marks to signify that it is a LTR region. Text will be then be rendered LTR irrespective of page's LTR or RTL direction. I then applied this function to any sentence in the application that included punctuation. This was inspired from a similar problem found here: https://stackoverflow.com/questions/20798667/why-is-a-trailing-punctuation-mark-rendered-at-the-start-with-directionrtl 

<img width="702" alt="Previous RTL Display" src="https://github.com/oss-slu/Seeing-is-Believing/assets/143125389/0ef5a7a5-5a89-48d6-a686-24a7f850dcac">

<img width="690" alt="Correct RTL Display" src="https://github.com/oss-slu/Seeing-is-Believing/assets/143125389/cdca5bd9-c058-4bdd-a49d-c4b887225cab">