### PR TITLE
Fixes Issue110

### DIFF
--- a/src/components/settings/AdminSettings.js
+++ b/src/components/settings/AdminSettings.js
@@ -9,6 +9,7 @@ import { useAuth } from '../../hooks/use-auth';
 import LightThemeIcon from '../light-theme.svg';
 import DarkThemeIcon from '../dark-theme.svg';
 import { useSettings } from '../../hooks/use-settings';
+import toast from 'react-hot-toast';
 
 const getValues = (settings) => ({
 	direction: settings.direction,
@@ -59,6 +60,7 @@ const AdminSettings = () => {
         firebase.auth().sendPasswordResetEmail(user.email)
             .then(() => {
                 setDisabled(true);
+				toast.success("Password Reset Email Sent");
                 // Set a timeout for how long you want the button to remain disabled
                 const disableDuration = 10000; // 5 minutes in milliseconds
                 setTimeout(() => setDisabled(false), disableDuration);
@@ -67,6 +69,7 @@ const AdminSettings = () => {
             })
             .catch((error) => {
                 // Handle any errors here
+				toast.error("Failed to send Password Reset Email");
                 console.error(error);
             });
     };

--- a/src/components/settings/StudentSettings.js
+++ b/src/components/settings/StudentSettings.js
@@ -9,6 +9,7 @@ import { useAuth } from '../../hooks/use-auth';
 import LightThemeIcon from '../light-theme.svg';
 import DarkThemeIcon from '../dark-theme.svg';
 import { useSettings } from '../../hooks/use-settings';
+import toast from 'react-hot-toast';
 
 const getValues = (settings) => ({
 	direction: settings.direction,
@@ -59,6 +60,7 @@ const StudentSettings = () => {
         firebase.auth().sendPasswordResetEmail(user.email)
             .then(() => {
                 setDisabled(true);
+				toast.success("Password Reset Email Sent");
                 // Set a timeout for how long you want the button to remain disabled
                 const disableDuration = 10000; // 5 minutes in milliseconds
                 setTimeout(() => setDisabled(false), disableDuration);
@@ -67,6 +69,7 @@ const StudentSettings = () => {
             })
             .catch((error) => {
                 // Handle any errors here
+				toast.error("Failed to send Password Reset Email");
                 console.error(error);
             });
     };

--- a/src/components/settings/TeacherSettings.js
+++ b/src/components/settings/TeacherSettings.js
@@ -9,6 +9,7 @@ import { useAuth } from '../../hooks/use-auth';
 import LightThemeIcon from '../light-theme.svg';
 import DarkThemeIcon from '../dark-theme.svg';
 import { useSettings } from '../../hooks/use-settings';
+import toast from 'react-hot-toast';
 
 const getValues = (settings) => ({
 	direction: settings.direction,
@@ -59,6 +60,7 @@ const TeacherSettings = () => {
         firebase.auth().sendPasswordResetEmail(user.email)
             .then(() => {
                 setDisabled(true);
+				toast.success("Password Reset Email Sent");
                 // Set a timeout for how long you want the button to remain disabled
                 const disableDuration = 10000; // 5 minutes in milliseconds
                 setTimeout(() => setDisabled(false), disableDuration);
@@ -67,6 +69,7 @@ const TeacherSettings = () => {
             })
             .catch((error) => {
                 // Handle any errors here
+				toast.error("Failed to send Password Reset Email");
                 console.error(error);
             });
     };


### PR DESCRIPTION
Fixes #issue_number 110

**What was changed?**

Added toast to reset password button to show that an email has or hasn't been sent in settings components

**Why was it changed?**

We wanted to notify users if the email was sent or not. User would not have verification that an email was being sent to reset their password, here I added that in form of a toast

**How was it changed?**

Used the previously installed react-hot-toast package to display a success or failure message. Changes are in adminSettings, studentSettings, and teacherSettings componets in the handle password reset function, we add two toasts.

**Screenshots that show the changes (if applicable):**
![image](https://github.com/oss-slu/Seeing-is-Believing/assets/123423248/607e8b75-c676-4408-8b9d-cb81fa38ce77)