### PR TITLE
Fixes issues 113, 105 and 118

### DIFF
--- a/src/components/authentication/firebase-register.js
+++ b/src/components/authentication/firebase-register.js
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 import {useRouter} from "next/router";
 import * as Yup from "yup";
 import {useFormik} from "formik";
@@ -22,24 +22,26 @@ import {useMounted} from "../../hooks/use-mounted";
 import {db} from '../../lib/firebase';
 
 export const FirebaseRegister = (props) => {
-	const {codes}=props
 	const isMounted = useMounted();
 	const router = useRouter();
 	const {createUserWithEmailAndPassword, getAuth} = useAuth();
 	const [isUserCreated, setIsUserCreated] = useState(false)
 	const [emailInUse, setEmailInUse] = useState(false)
-	var [isDisabled, setIsDisabled] = useState(false);
-	var toggleDisable = () => {
-		setIsDisabled(!isDisabled); // Toggle the state to enable or disable the TextField
-	  };
-	  if(window.location.search !== "") {
-		if(window.location.search.split('=')[1].length > 0) { 
-			isDisabled = "none" 
+	const [showStatus, setShowStatus] = useState(true); // Use showStatus to control visibility
+
+	useEffect(() => {
+		const queryString = window.location.search;
+		const show = !queryString.includes('=') || queryString.split('=')[1] === '';
+		setShowStatus(show);
+	  
+		// Automatically set status to "Administrator" if we're hiding the status field
+		if (!show) {
+		  formik.setFieldValue("status", "Administrator");
+		  formik.setFieldTouched("status");
 		}
-		else {
-			isDisabled = false
-		}
-	  }
+	  }, [router.asPath]); // Depend on router.asPath to react to URL changes
+
+
 	const formik = useFormik({
 		initialValues: {
 			firstName: "",
@@ -48,7 +50,6 @@ export const FirebaseRegister = (props) => {
 			password: "",
 			confirmPassword: "",
 			status: "",
-			//code: "", Use this if we add the code functionality back
 			organizations: "",
 			policy: true,
 			submit: null,
@@ -71,25 +72,11 @@ export const FirebaseRegister = (props) => {
 				.required("Required *")
 				.oneOf([Yup.ref("password"), null], "Password doesn't match"),
 			status: Yup.string().required("Required *"),     
-			//code: Yup.string().required("Required *"), code functionality
 			organizations: Yup.string().required("Required *"),
 			policy: Yup.boolean().oneOf([true], "This field must be checked"),
 		}),
 		onSubmit: async (values, helpers) => {
 			try {
-				/*switch (values.status) {
-					case "Student":
-						if(values.code!=codes.student){throw new Error('Wrong verification code!');}
-						break;
-					case "Teacher":
-						if(values.code!=codes.teacher){throw new Error('Wrong verification code!');}
-						break;
-					//case "Administrator":
-						//if(values.code!=codes.admin){throw new Error('Wrong verification code!')}
-						//break;
-					default:
-						break;
-				} code functionality for sign up */
 				const userCreated = await createUserWithEmailAndPassword(
 					values.email,
 					values.password
@@ -223,26 +210,13 @@ export const FirebaseRegister = (props) => {
 					type="password"
 					value={formik.values.confirmPassword}
 				/>
-				{/* this is all commented out because we are removing the code from sign up functionality  
-				<Grid container spacing={3}> 
-					<Grid item md={6} xs={12}>
-						<FormControl
-							variant="standard"
-							sx={{mt: 2, minWidth: "100%"}}
-							error={Boolean(
-								formik.touched.status && formik.errors.status
-							)}
-						>
-							<InputLabel id="status">Status</InputLabel>
-							<Select
-								displayEmpty
-								labelId="status"
-								fullWidth
-								name="status"
-								onBlur={formik.handleBlur}
-								onChange={formik.handleChange}
-								value={formik.values.status}
-							>
+				
+				{showStatus && (
+          		<FormControl variant="standard" sx={{ mt: 2, minWidth: "100%" }}
+                       error={Boolean(formik.touched.status && formik.errors.status)}>
+            			<InputLabel id="status">Status</InputLabel>
+						<Select labelId="status" name="status"
+							value={formik.values.status} onChange={formik.handleChange}>
 								{status.map((item, pos) => {
 									return (
 										<MenuItem key={pos} value={item.title}>
@@ -250,60 +224,12 @@ export const FirebaseRegister = (props) => {
 										</MenuItem>
 									);
 								})}
-							</Select>
-						</FormControl>
-					</Grid> 
-					<Grid item md={6} xs={12}>
-						<TextField
-							error={Boolean(
-								formik.touched.code && formik.errors.code
-							)}
-							fullWidth
-							helperText={
-								formik.touched.code && formik.errors.code
-							}
-							label="Code"
-							margin="normal"
-							name="code"
-							onBlur={formik.handleBlur}
-							onChange={formik.handleChange}
-							type="text"
-							value={formik.values.code}
-						/>
-					</Grid> 
-						</Grid>*/}
-				<FormControl
-							variant="standard"
-							sx={{mt: 2, minWidth: "100%"}}
-							error={Boolean(
-								formik.touched.status && formik.errors.status
-							)}
-						>
-							<InputLabel id="status" style={{ display: isDisabled }}>Status</InputLabel>
-							<Select
-							style={{ display: isDisabled }}
-								displayEmpty
-								labelId="status"
-								fullWidth
-								name="status"
-								onBlur={formik.handleBlur}
-								onChange={(event) => {
-									formik.handleChange(event);
-									if (isDisabled !== false) {
-										formik.setFieldValue("status", "Administrator");
-									}
-								}}
-								value={formik.values.status}
-							>
-								{status.map((item, pos) => {
-									return (
-										<MenuItem key={pos} value={item.title}>
-											{item.title}
-										</MenuItem>
-									);
-								})}
-							</Select>
-						</FormControl>
+						</Select>
+						{formik.touched.status && formik.errors.status && (
+              			<FormHelperText error>{formik.errors.status}</FormHelperText>
+            			)}
+          		</FormControl>
+        )}
 				<Box mb={3}>
 					<FormControl
 						variant="standard"

--- a/src/contexts/firebase-auth-context.js
+++ b/src/contexts/firebase-auth-context.js
@@ -37,26 +37,43 @@ export const AuthProvider = (props) => {
   
   const fetchUserData = async (user) => {
     const collection = await db.collection("users");
-    let results;
+    let userFound = false; // Flag to check if user document exists
     await collection
       .where("email", "==", user.email)
       .get()
       .then((snapshot) => {
-        results = {id:snapshot.docs[0].id,...snapshot.docs[0].data()}
-      });
-
-    dispatch({
-      type: 'AUTH_STATE_CHANGED',
-      payload: {
-        isAuthenticated: true,
-        user: {
-          id: results.id,
-          avatar: user.photoURL,
-          ...results
+        if (snapshot.docs.length > 0) {
+          const userData = snapshot.docs[0].data();
+          dispatch({
+            type: 'AUTH_STATE_CHANGED',
+            payload: {
+              isAuthenticated: true,
+              user: {
+                id: snapshot.docs[0].id,
+                avatar: user.photoURL,
+                ...userData
+              }
+            }
+          });
+          userFound = true;
+        } else {
+          console.error('No user document found with this email');
         }
-      }
-    });
+      });
+  
+    if (!userFound) {
+      // Dispatch a different action or handle the "user not found" state
+      // For example, you might want to set isAuthenticated to false
+      dispatch({
+        type: 'AUTH_STATE_CHANGED',
+        payload: {
+          isAuthenticated: false,
+          user: null
+        }
+      });
+    }
   };
+  
   
   useEffect(() => firebase.auth().onAuthStateChanged((user) => {
     if (user) {

--- a/src/contexts/firebase-auth-context.js
+++ b/src/contexts/firebase-auth-context.js
@@ -63,7 +63,6 @@ export const AuthProvider = (props) => {
   
     if (!userFound) {
       // Dispatch a different action or handle the "user not found" state
-      // For example, you might want to set isAuthenticated to false
       dispatch({
         type: 'AUTH_STATE_CHANGED',
         payload: {


### PR DESCRIPTION
Fixes #issue_number 113, 105, and 118

**What was changed?**

1. Alterations to the firebase-register component. Specifically when hiding the status dropdown, before we were ignoring the validation scheme which required the field to be touched by the user before submitting the form. Before, we checked if the search bar had something after =, now I've wrapped that in a useEffect, that sets status to admin and sets the status field to touched. Also removed comments from the file.

2. Alteration to firebase-auth-context file. Specifically the fetchUserData function now checks for a user and avoids a runtime error if the database needs a second to update. 

3. Subsequently, the error checking for runtime also solved the issue of a new administrator being routed incorrectly to a student landing page. Now the new admin is routed correctly to an administrator landing page.

**Why was it changed?**

1. The issue was that even when we hide the status bar and render the page correctly, we were unable to register the new admin. As mentioned above this was an issue with the field not being touched, so now when we hide the status bar we also set the field to touched and set status to admin.

2. We were facing runtimes errors upon registration, now we make sure that this runtime error doesn't occur by error checking.

3. Our new admins were being routed to the wrong landing page, and this had to do with the fact that our firebase user doc wasn't updating as fast as our application.

**How was it changed?**

1. The main file that needed to be changed was the src/authentication/firebase-register.js file. In this file we have the component for the register form. While previously it accurately hid the status bar when signing up new admins, it was simply a state variable, which is now wrapped in a useEffect. The new state variable is showStatus, and is wrapped in a useEffect so instead of simply hiding the ui component, it also handles the backend logic of allowing the validation scheme to validate, and setting the status to administrator.

2. Added error checking in the fetchUserData function of firebase-auth-context file to ensure that if the user isn't found we do not try to assign variables from that user's doc on firebase.

3. Same as part two. 

**Screenshots that show the changes**

1.
![image](https://github.com/oss-slu/Seeing-is-Believing/assets/123423248/448caeed-38c8-41bf-b39c-a873e1a38524)

2.
Before: 
![image](https://github.com/oss-slu/Seeing-is-Believing/assets/123423248/0ab1ecf9-9993-490d-ad1a-332c862120a6)

After:
![image](https://github.com/oss-slu/Seeing-is-Believing/assets/123423248/fa8b50a6-1938-4a0c-a493-d6d1fc982991)
3.
N/A