### PR TITLE
Added email validation for Admin Invite

### DIFF
--- a/src/components/dashboard/account-popover.js
+++ b/src/components/dashboard/account-popover.js
@@ -33,8 +33,25 @@ export const AccountPopover = (props) => {
   const { user,logout } = useAuth();
   const [inviteUserDialogOpen, setInviteUserDialogOpen] = useState(false);
   const [userEmail, setUserEmail] = useState(' ');
+  const [validMail,setValidMail]=useState(false)
   const {createUserWithEmailAndPassword, getAuth} = useAuth();
   const {sendPasswordResetEmail} = useAuth();
+  const [error, setError] = useState(false);
+
+
+  const validateEmail = (email) => {
+    return email.match(
+      /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+    );
+  };
+  const handleInputChange = (e) => {
+    const email = e.target.value;
+    setUserEmail(email);
+
+    const isValidEmail = validateEmail(email)
+    setValidMail(isValidEmail)
+    setError(!isValidEmail);
+  };
 
   const handleInviteUser = async () => {
     try {
@@ -306,23 +323,33 @@ export const AccountPopover = (props) => {
       <DialogTitle>Invite Admin</DialogTitle>
       <DialogContent>
       <TextField
-        label="User Email"
-        variant="outlined"
-        fullWidth
-        value={userEmail}
-        onChange={(e) => setUserEmail(e.target.value)}
-        sx={{
-          marginTop: '20px'
-        }}
-        />
+      label="User Email"
+      variant="outlined"
+      fullWidth
+      type="email"
+      value={userEmail}
+      onChange={handleInputChange}
+      error={error}
+      helperText={error ? 'Invalid email format' : ''}
+      sx={{
+        marginTop: '20px'
+      }}
+    />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleCloseInviteUserDialog} color="primary">
           Cancel
         </Button>
-        <Button onClick={handleInviteUser} color="primary">
-          Invite
-        </Button>
+        
+        {validMail ? (
+    <Button onClick={handleInviteUser} color="primary">
+      Invite
+    </Button>
+  ) : ( 
+    <Button disabled color="primary">
+      Invite
+    </Button>
+  )}
       </DialogActions>
     </Dialog>
     </div>


### PR DESCRIPTION
Fixes #112 

Added email validation to invite admin.
Input box is highlighted red, error message displayed and the invite button is disabled for invalid emails.

![image](https://github.com/oss-slu/Seeing-is-Believing/assets/91091885/a4fd12b0-ee5f-4e1e-ab7b-6066e1419f45)

![image](https://github.com/oss-slu/Seeing-is-Believing/assets/91091885/ba6226a1-964f-4516-9218-5367446b05f8)

What was changed?
All changes in account-popover.js

How was it changed?
Added a custom email validator using regex and new state variable(validEmail) to maintain logic.
