### PR TITLE
WIP on Issue 112

### DIFF
--- a/src/components/dashboard/account-popover.js
+++ b/src/components/dashboard/account-popover.js
@@ -25,7 +25,6 @@ import { useAuth } from '../../hooks/use-auth';
 import { Cog as CogIcon } from '../../icons/cog';
 import { UserCircle as UserCircleIcon } from '../../icons/user-circle';
 import React, { useState } from 'react';
-import firebase from "../../lib/firebase";
 
 export const AccountPopover = (props) => {
   const { anchorEl, onClose, open, ...other } = props;
@@ -33,11 +32,18 @@ export const AccountPopover = (props) => {
   const { user,logout } = useAuth();
   const [inviteUserDialogOpen, setInviteUserDialogOpen] = useState(false);
   const [userEmail, setUserEmail] = useState(' ');
-  const {createUserWithEmailAndPassword, getAuth} = useAuth();
-  const {sendPasswordResetEmail} = useAuth();
+  const [isValidEmail, setIsValidEmail] = useState(true);
+
+  const validateEmail = (email) => {
+    const validDomain = '@example.com'; // Set the valid domain
+    const isValid = email.endsWith(validDomain);
+    setIsValidEmail(isValid);
+    return isValid;
+  };
 
   const handleInviteUser = async () => {
 
+    if (!validateEmail(userEmail.trim())) return;
     
     try {
       const email = userEmail.trim();
@@ -58,6 +64,11 @@ export const AccountPopover = (props) => {
       toast.error('Failed to invite admin.')
     }
     handleCloseInviteUserDialog();
+  };
+
+  const handleChangeEmail = (event) => {
+    setUserEmail(event.target.value);
+    validateEmail(event.target.value);
   };
 
   const handleOpenInviteUserDialog = () => {
@@ -310,21 +321,21 @@ export const AccountPopover = (props) => {
       <DialogTitle>Invite Admin</DialogTitle>
       <DialogContent>
       <TextField
-        label="User Email"
-        variant="outlined"
-        fullWidth
-        value={userEmail}
-        onChange={(e) => setUserEmail(e.target.value)}
-        sx={{
-          marginTop: '20px'
-        }}
-        />
+            label="User Email"
+            variant="outlined"
+            fullWidth
+            value={userEmail}
+            onChange={handleChangeEmail}
+            error={!isValidEmail}
+            helperText={!isValidEmail && "Email must be valid"}
+            sx={{ marginTop: '20px', borderColor: !isValidEmail ? 'red' : 'default' }}
+          />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleCloseInviteUserDialog} color="primary">
           Cancel
         </Button>
-        <Button onClick={handleInviteUser} color="primary">
+        <Button onClick={handleInviteUser} color="primary" disabled={!isValidEmail}>
           Invite
         </Button>
       </DialogActions>


### PR DESCRIPTION
Fixes issue 112

**What was changed?**

Account popover was changed, so that it keeps track of state of validity of email and will update our text input box to be red if it is not valid and disable the button if it's not valid. Right now it is based on a validation function that is not fully implemented, right now it just checks if the email ends with 'example.com' but fixing this function to include all valid domains will mean we accurately check emails.

**Why was it changed?**

We want to make sure all email input in this box will be valid emails to send invites to. This is a nice looking thing for our program.

**How was it changed?**

Added a state variable for isValidEmail, made the button disabled if the state is false, and the box red if the state is false. Upon a change in the text input we update this variable by trying to validate the input. 

**Screenshots that show the changes (if applicable):**

![image](https://github.com/oss-slu/Seeing-is-Believing/assets/123423248/cb062387-e5b6-4bc0-8665-fc1c1a24235a)
