### PR TITLE
Changes necessary to run SIB through Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:18-alpine
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json (or yarn.lock)
+COPY package.json package-lock.json* ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# The port Next.js will listen on
+EXPOSE 3000
+
+# Command to start the Next.js application
+CMD ["npm", "start"]

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "react-swipeable-views": "^0.14.0",
     "react-syntax-highlighter": "^15.4.3",
     "react-wavesurfer.js": "0.0.5",
-    "recompose": "^0.17.0",
     "recorder-js": "^1.0.7",
     "serve": "^14.2.1",
     "simplebar": "^5.3.6",


### PR DESCRIPTION
Issue Partly Fixes Issue #126 

**What was changed?**
I installed Docker on my local machine and created a Dockerfile that allows for an instance of SIB to be run on a Docker container.

**Why was it changed?**
This change is necessary when working towards a solution to the Canvas integration problem because aDocker container can be used to facilitate interactions between Moodle/Canvas and SIB.

**How was it changed?**
Other than creating the Dockerfile, I modified package.json because "recompose" was causing the Docker build to fail due to versioning problems. 

Here are the steps to spin this up on your local machine:
1. Install Docker on your local machine
2. Build Docker Image
```docker build -t sib .```
Run Docker Container
```docker run --env-file .env.production -p 3000:3000 sib```
